### PR TITLE
Make Blas.set_num_threads a context manager

### DIFF
--- a/neurtu/blas.py
+++ b/neurtu/blas.py
@@ -130,7 +130,6 @@ class Blas(object):
 
         Examples
         --------
-
         >>> blas = Blas()   #doctest: +SKIP
         >>> blas.set_num_threads(1)  #doctest: +SKIP
         >>> with blas.set_num_threads(4):  #doctest: +SKIP

--- a/neurtu/tests/test_base.py
+++ b/neurtu/tests/test_base.py
@@ -73,7 +73,7 @@ def test_memit_array_allocation():
 
     res = memit(delayed(allocate_array)())
     assert res['peak_memory_mean'] == approx(N**2*double_size / 1024**2,
-                                             rel=0.01)
+                                             rel=0.02)
 
 
 @pytest.mark.parametrize('aggregate', ['aggregate', None])

--- a/neurtu/tests/test_blas.py
+++ b/neurtu/tests/test_blas.py
@@ -75,12 +75,20 @@ def test_blas_set_threads(blas_name):
 
     num_threads_1 = 1
 
+    # setting the number of threads without a context manager
     blas.set_num_threads(num_threads_1)
 
     assert blas.get_num_threads() == num_threads_1
 
     # get back to the original number of threads
     blas.set_num_threads(num_threads_0)
+
+    assert blas.get_num_threads() == num_threads_0
+
+    # setting the number of threads with a context manager
+
+    with blas.set_num_threads(num_threads_1):
+        assert blas.get_num_threads() == num_threads_1
 
     assert blas.get_num_threads() == num_threads_0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,7 @@ addopts =
     --doctest-modules
     --ignore=doc/conf.py
     --ignore=doc/sphinxext/
+    --ignore=examples/
     -rs
 [bdist_wheel]
 universal=1


### PR DESCRIPTION
This makes `Blas.set_num_threads` optionally work inside a `with` statement. 