### PR TITLE
[WIP] Automatic tag inference

### DIFF
--- a/neurtu/tags.py
+++ b/neurtu/tags.py
@@ -1,0 +1,83 @@
+# neurtu, BSD 3 clause license
+# Authors: Roman Yurchak
+
+
+class TagsInferenceException(BaseException):
+    pass
+
+
+def _eval_as_bool(x):
+    """Given the result of an equality evaluation
+    x = (a == b)
+    convert the result to a bool
+    """
+
+    if hasattr(x, 'all'):
+        x = x.all()
+
+    if isinstance(x, bool):
+        return x
+    elif x.__class__.__name__ == 'bool_':
+        # numpy.bool_ case
+        return bool(x)
+    elif 'Series' in x.__class__.__name__:
+        # pandas.DataFrame reduced to a pandas.Series
+        return bool(x.all())
+    elif x.__class__.__name__ in ['csr_matrix', 'csc_matrix']:
+        return bool(x.data.all())
+
+    raise TagsInferenceException(
+            "Could not compute the truth value of %s" % x)
+
+
+def _check_equal(a, b):
+    """Check that two objects are equal
+
+    This also supports numpy like objects
+    """
+    if id(a) == id(b):
+        return True
+    res = _eval_as_bool(a == b)
+    return res
+
+
+def _check_equal_dict(a, b):
+    """Check that two dictionaries are equal"""
+    if set(a.keys()) != set(b.keys()):
+        return False
+    res = []
+    for key in a:
+        res.append(_check_equal(a[key], b[key]))
+    return all(res)
+
+
+def _check_equal_all(iterator):
+    """Check that all elements in an iterable are equal"""
+    iterator = iter(iterator)
+    try:
+        first = next(iterator)
+    except StopIteration:
+        return True
+    return all(_check_equal_dict(first, rest) for rest in iterator)
+
+
+def _select_relevant_tags(tags):
+    """
+    Select the relevant tags from raw tags
+
+    Parameters
+    ----------
+    tags : list of list of dicts
+       input tags
+
+    Returns
+    -------
+    tags: list of list of dicts
+       list of relevant tags
+    """
+
+    mask = list(not _check_equal_all(el) for el in zip(*tags))
+
+    return [[inner for idx, inner in enumerate(tags_sample)
+             if mask[idx]]
+            for tags_sample in tags]

--- a/neurtu/tests/test_delayed.py
+++ b/neurtu/tests/test_delayed.py
@@ -14,3 +14,17 @@ def test_set_env():
     assert delayed(func, env={'NEURTU_TEST': 'true'})().compute() == 'true'
 
     assert func() is None
+
+
+def test_infer_tags():
+    obj = delayed(None)(x=1)
+    assert obj.get_tags(infer=True) == [{'x': 1}]
+
+    obj = delayed(None)(y='ze').get(x=3)
+    assert obj.get_tags(infer=True) == [{'x': 3}, {'y': "ze"}]
+
+    obj = delayed(None)(1)
+    assert obj.get_tags(infer=True) == [{'arg_0': 1}]
+
+    obj = delayed(None)(a=1)[23]
+    assert obj.get_tags(infer=True) == [{'arg_0': 23}, {'a': 1}]

--- a/neurtu/tests/test_tags.py
+++ b/neurtu/tests/test_tags.py
@@ -1,0 +1,92 @@
+# neurtu, BSD 3 clause license
+# Authors: Roman Yurchak
+
+import pytest
+
+from neurtu.tags import _select_relevant_tags, _eval_as_bool
+
+
+def test_select_relevant_tags():
+
+    tags = [[{'a': 1}, {'b': 2}],
+            [{'a': 2}, {'b': 2}]]
+
+    tags_relevant = _select_relevant_tags(tags)
+    assert tags_relevant == [[{'a': 1}], [{'a': 2}]]
+
+
+def test_select_relevant_tags_numpy():
+    np = pytest.importorskip('numpy')
+
+    x = np.ones(10)
+    x_2 = np.ones(10)
+    y = np.ones(10)*2
+
+    tags = [[{'a': x}, {'b': x}, {'c': x}],
+            [{'a': y}, {'b': x}, {'c': x_2}]]
+
+    tags_relevant = _select_relevant_tags(tags)
+    assert tags_relevant == [[{'a': x}], [{'a': y}]]
+
+
+def test_select_relevant_tags_pandas():
+    pd = pytest.importorskip('pandas')
+
+    x = pd.DataFrame([{'a': 2, 'b': 3}])
+    x_2 = pd.DataFrame([{'a': 2, 'b': 3}])
+    y = pd.DataFrame([{'a': 2, 'b': 1}])
+
+    tags = [[{'a': x}, {'b': x}, {'c': x}],
+            [{'a': y}, {'b': x}, {'c': x_2}]]
+
+    tags_relevant = _select_relevant_tags(tags)
+    assert tags_relevant == [[{'a': x}], [{'a': y}]]
+
+
+# Equality tests
+
+
+@pytest.mark.parametrize('x', [True, False])
+def test_eval_bool_as_bool(x):
+    res = _eval_as_bool(x)
+    assert isinstance(res, bool)
+    assert res is x
+
+
+def test_eval_as_bool_numpy_array():
+    np = pytest.importorskip('numpy')
+    x = np.ones((10, 10))
+    y = np.ones((10, 10))
+    res = _eval_as_bool(x == y)
+    assert isinstance(res, bool)
+    assert res is True
+
+
+@pytest.mark.filterwarnings('ignore:Comparing sparse matrices', 'ignore:something_else')
+def test_eval_as_bool_scipy_sparse():
+    sp = pytest.importorskip('scipy.sparse')
+    np = pytest.importorskip('numpy')
+
+    x = sp.csr_matrix(np.ones((10, 10)))
+    y = sp.csr_matrix(np.ones((10, 10)))
+    res = _eval_as_bool(x == y)
+    assert isinstance(res, bool)
+    assert res is True
+
+
+def test_eval_as_bool_pandas_frame():
+    pd = pytest.importorskip('pandas')
+    x = pd.DataFrame([{'a': 2, 'b': 2}])
+    y = pd.DataFrame([{'a': 2, 'b': 2.}])
+    res = _eval_as_bool(x == y)
+    assert isinstance(res, bool)
+    assert res is True
+
+
+def test_eval_as_bool_pandas_series():
+    pd = pytest.importorskip('pandas')
+    x = pd.Series({'a': 2, 'b': 2})
+    y = pd.Series({'a': 2, 'b': 2.})
+    res = _eval_as_bool(x == y)
+    assert isinstance(res, bool)
+    assert res


### PR DESCRIPTION
The goal of this PR was to do automatic tag inference, for instance instead of,

```py
>>> import numpy as np
>>> from neurtu import delayed, timeit
>>> timeit(delayed(np.ones, tags={'N': N})(N).sum() for N in [1000, 10000, 100000])
       wall_time
N               
500     0.000250
1000    0.001134
10000   0.283048
```
where we time the execution of `np.ones(N).sum()`,  with each run being explicitly tagged with `tags={'N': N}` specifying the relevant parameters that change between runs, do simply,

```py
>>> timeit(delayed(np.ones)(N).sum() for N in [1000, 10000, 100000])
```
and do the system infer tags on its own. Which has the advantage of being more concise.

