### PR TITLE
MAINT Test examples in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,8 +52,8 @@ script:
   - |
       if [[ "${BUILD_DOCS}" == "true" ]]; then
          cd doc/
-         pip install -e requirements.txt
-         make htm
+         pip install -r requirements.txt
+         make html
       fi
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: false
 matrix:
   include:
     - python: 2.7
-      env: REQUIREMENTS="numpy==1.8.0 pandas==0.20.0rc1" RUN_COVERAGE=true  INSTALLER="pip"
+      env: REQUIREMENTS="numpy==1.8.0 pandas==0.20.0rc1" RUN_COVERAGE=true  BUILD_DOCS=true INSTALLER="pip"
     - python: 3.4
       env: REQUIREMENTS="numpy pandas==0.20.0rc1" RUN_COVERAGE=true INSTALLER="pip"
     - python: 3.5
@@ -13,7 +13,7 @@ matrix:
     - python: 3.6
       env: REQUIREMENTS="numpy pandas tqdm"  RUN_COVERAGE=true  INSTALLER="conda"
     - python: 3.6
-      env: REQUIREMENTS="numpy pandas tqdm nomkl"  RUN_COVERAGE=true  INSTALLER="conda"
+      env: REQUIREMENTS="numpy pandas tqdm nomkl"  RUN_COVERAGE=true  BUILD_DOCS=true INSTALLER="conda"
     - language: generic
       os: osx
       python: 3.6
@@ -49,6 +49,12 @@ script:
          source activate neurtu-env
       fi
   - pytest -s --doctest-modules --cov=neurtu neurtu/
+  - |
+      if [[ "${BUILD_DOCS}" == "true" ]]; then
+         cd doc/
+         pip install -e requirements.txt
+         make htm
+      fi
 
 after_success:
   - |

--- a/examples/logistic_regression_scaling.py
+++ b/examples/logistic_regression_scaling.py
@@ -58,7 +58,7 @@ ax.set_title('Run time scaling for LogisticRegression.fit')
 #
 # Similarly the memory scaling is represented below,
 
-ax = df.set_index(['N', 'solver']).peak_memory.unstack().plot(marker='o')
+ax = df.peak_memory.unstack().plot(marker='o')
 ax.set_xscale('log')
 ax.set_yscale('log')
 ax.set_ylabel('Peak memory (MB)')

--- a/examples/logistic_regression_scaling.py
+++ b/examples/logistic_regression_scaling.py
@@ -22,7 +22,7 @@ y = rng.randint(2, size=(n_samples))
 
 
 def benchmark_cases():
-    for N in np.geomspace(100, n_samples, 5, dtype='int'):
+    for N in np.logspace(np.log10(100), np.log10(n_samples), 5).astype('int'):
         for solver in ['newton-cg', 'lbfgs', 'liblinear', 'sag', 'saga']:
             tags = {'N': N, 'solver': solver}
             model = delayed(LogisticRegression, tags=tags)(

--- a/neurtu/tests/test_benchmark.py
+++ b/neurtu/tests/test_benchmark.py
@@ -49,8 +49,8 @@ def test_memit_overhead():
     res = memit(delayed(sleep)(0.1))
     assert isinstance(res, dict)
 
-    # measurement error is less than 0.5 MB
-    assert res['peak_memory'] < 0.5
+    # measurement error is less than 1.0 MB
+    assert res['peak_memory'] < 1.0
 
 
 def test_memit_array_allocation():


### PR DESCRIPTION
Currently examples can fail in Readthedocs when a PR that passed all CI tests is merged into master.

This tries to prevent this situation by building the docs on Travis as well, which in particular will detect any issues in examples.